### PR TITLE
fix: Fixed a bug causing the blanket route to crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [1.2.1](https://github.com/sbrow/laravel-blanket/compare/v1.2.0...v1.2.1) (2022-07-05)
+
+
+### Bug Fixes
+
+* Fixed a bug causing the blanket route to crash ([ab61421](https://github.com/sbrow/laravel-blanket/commit/ab614218e1fd18b8158cf5670e036edd7b922bed))

--- a/src/Models/Log.php
+++ b/src/Models/Log.php
@@ -26,7 +26,7 @@ class Log extends Model
 
     public function getPathAttribute(): string
     {
-        return parse_url($this->url, PHP_URL_PATH);
+        return parse_url($this->url, PHP_URL_PATH) ?? '';
     }
 
     public function getCreatedAtAttribute(?string $date): ?string


### PR DESCRIPTION
Sometimes urls will return null as their path which was causing the blanket view to stop rendering.

This pull request causes the `path` attribute to return '' instead of null, which prevents the type error from being thrown.